### PR TITLE
Update settings import for 6.0 compatibility

### DIFF
--- a/sentry_jira/plugin.py
+++ b/sentry_jira/plugin.py
@@ -1,10 +1,10 @@
 import urllib
 import urlparse
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
-from sentry.conf import settings
 from sentry.models import GroupMeta
 from sentry.plugins.base import Response
 from sentry.plugins.bases.issue import IssuePlugin


### PR DESCRIPTION
FYI this will break compatibility with pre 6.0 release.

We could do a try/except in all fairness, or just look for SENTRY_AUTH_PROVIDERS if AUTH_PROVIDERS does not exist
