### PR TITLE
Provide support for default priority and default issue type when creating JIRA tickets.

### DIFF
--- a/sentry_jira/forms.py
+++ b/sentry_jira/forms.py
@@ -154,7 +154,6 @@ CUSTOM_FIELD_TYPES = {
 
 class JIRAIssueForm(forms.Form):
 
-    project_key = forms.CharField(widget=forms.HiddenInput())
     project = forms.CharField(widget=forms.HiddenInput())
     issuetype = forms.ChoiceField(
         label="Issue Type",


### PR DESCRIPTION
Also expose an auto-create button for filing JIRA tickets.

One known limitation: you must update the project name to update the default issue type if they are different across different projects.  I tried a bunch of different JS approaches to do it, but figured the easier thing for now is just to require 2 saves.

![image](https://cloud.githubusercontent.com/assets/326857/3207131/b0715f6c-edd5-11e3-82fd-fd2f11d13775.png)
