### PR TITLE
Rogerhu improvements + Update issue keys

### DIFF
--- a/sentry_jira/forms.py
+++ b/sentry_jira/forms.py
@@ -6,6 +6,10 @@ from .jira import JIRAClient
 
 log = logging.getLogger(__name__)
 
+class JIRAFormUtils(object):
+    @staticmethod
+    def make_choices(x):
+        return [(y["id"], y["name"] if "name" in y else y["value"]) for y in x] if x else []
 
 class JIRAOptionsForm(forms.Form):
     instance_url = forms.CharField(
@@ -36,6 +40,21 @@ class JIRAOptionsForm(forms.Form):
         required=False
     )
 
+    default_priority = forms.ChoiceField(
+        label=_("Default Priority"),
+        required=False
+    )
+
+    default_issue_type = forms.ChoiceField(
+        label=_("Default Issue Type"),
+        required=False)
+
+    auto_create = forms.BooleanField(
+        label=_("Auto create JIRA tickets"),
+        help_text=_("Only enable if you want any new event to auto-create a JIRA ticket."),
+        required=False
+    )
+
     def __init__(self, *args, **kwargs):
         super(JIRAOptionsForm, self).__init__(*args, **kwargs)
 
@@ -51,6 +70,19 @@ class JIRAOptionsForm(forms.Form):
                     project_choices = [(p.get('key'), "%s (%s)" % (p.get('name'), p.get('key'))) for p in projects]
                     project_safe = True
                     self.fields["default_project"].choices = project_choices
+
+            priorities_response = jira.get_priorities()
+            if priorities_response.status_code == 200:
+                priorities = priorities_response.json
+                if priorities:
+                    priority_choices = [(p.get('id'), "%s" % (p.get('name'))) for p in priorities]
+                    self.fields["default_priority"].choices = priority_choices
+
+            default_project = initial.get('default_project')
+            if default_project:
+                meta = jira.get_create_meta_for_project(default_project)
+                if meta:
+                    self.fields["default_issue_type"].choices = JIRAFormUtils.make_choices(meta["issuetypes"])
 
         if not project_safe:
             del self.fields["default_project"]
@@ -123,7 +155,6 @@ CUSTOM_FIELD_TYPES = {
 
 class JIRAIssueForm(forms.Form):
 
-    project_key = forms.CharField(widget=forms.HiddenInput())
     project = forms.CharField(widget=forms.HiddenInput())
     issuetype = forms.ChoiceField(
         label="Issue Type",
@@ -142,15 +173,16 @@ class JIRAIssueForm(forms.Form):
     def __init__(self, *args, **kwargs):
         self.ignored_fields = kwargs.pop("ignored_fields")
         initial = kwargs.get("initial")
-        jira_client = initial.pop("jira_client")
+        jira_client = kwargs.pop("jira_client")
+        project_key = kwargs.pop("project_key")
 
         priorities = jira_client.get_priorities().json
-        versions = jira_client.get_versions(initial.get("project_key")).json
+        versions = jira_client.get_versions(project_key).json
 
         # Returns the metadata the configured JIRA instance requires for
         # creating issues for a given project.
         # https://developer.atlassian.com/static/rest/jira/5.0.html#id200251
-        meta = jira_client.get_create_meta(initial.get("project_key")).json
+        meta = jira_client.get_create_meta(project_key).json
 
         # Early exit, somehow made it here without properly configuring the
         # plugin.
@@ -190,7 +222,7 @@ class JIRAIssueForm(forms.Form):
         super(JIRAIssueForm, self).__init__(*args, **kwargs)
 
         self.fields["project"].initial = project["id"]
-        self.fields["issuetype"].choices = self.make_choices(issue_types)
+        self.fields["issuetype"].choices = JIRAFormUtils.make_choices(issue_types)
 
         # apply ordering to fields based on some known built-in JIRA fields.
         # otherwise weird ordering occurs.
@@ -214,12 +246,10 @@ class JIRAIssueForm(forms.Form):
         if "priority" in self.fields.keys():
             # whenever priorities are available, put the available ones in the list.
             # allowedValues for some reason doesn't pass enough info.
-            self.fields["priority"].choices = self.make_choices(priorities)
+            self.fields["priority"].choices = JIRAFormUtils.make_choices(priorities)
 
         if "fixVersions" in self.fields.keys():
-            self.fields["fixVersions"].choices = self.make_choices(versions)
-
-    make_choices = lambda self, x: [(y["id"], y["name"] if "name" in y else y["value"]) for y in x] if x else []
+            self.fields["fixVersions"].choices = JIRAFormUtils.make_choices(versions)
 
     def clean_description(self):
         """
@@ -280,8 +310,6 @@ class JIRAIssueForm(forms.Form):
             # above clean method.)
             very_clean["issuetype"] = {"id": very_clean["issuetype"]}
 
-        very_clean.pop("project_key", None)
-
         return very_clean
 
     def build_dynamic_field(self, field_meta):
@@ -301,7 +329,7 @@ class JIRAIssueForm(forms.Form):
         if (schema["type"] in ["securitylevel", "priority"]
                 or schema.get("custom") == CUSTOM_FIELD_TYPES.get("select")):
             fieldtype = forms.ChoiceField
-            fkwargs["choices"] = self.make_choices(field_meta.get('allowedValues'))
+            fkwargs["choices"] = JIRAFormUtils.make_choices(field_meta.get('allowedValues'))
             fkwargs["widget"] = forms.Select()
         elif schema.get("items") == "user" or schema["type"] == "user":
             fkwargs["widget"] = forms.TextInput(attrs={'class': 'user-selector', 'data-autocomplete': field_meta.get("autoCompleteUrl")})
@@ -313,7 +341,7 @@ class JIRAIssueForm(forms.Form):
             return None
         elif schema["type"] == "array" and schema["items"] != "string":
             fieldtype = forms.MultipleChoiceField
-            fkwargs["choices"] = self.make_choices(field_meta.get("allowedValues"))
+            fkwargs["choices"] = JIRAFormUtils.make_choices(field_meta.get("allowedValues"))
             fkwargs["widget"] = forms.SelectMultiple()
 
         # break this out, since multiple field types could additionally

--- a/sentry_jira/jira.py
+++ b/sentry_jira/jira.py
@@ -34,6 +34,21 @@ class JIRAClient(object):
     def get_create_meta(self, project):
         return self.make_request('get', self.META_URL, {'projectKeys': project, 'expand': 'projects.issuetypes.fields'})
 
+    def get_create_meta_for_project(self, project):
+        response = self.get_create_meta(project)
+
+        if not response:
+            raise Exception("Could not find project")
+
+        metas = response.json
+
+        if len(metas["projects"]) > 1:
+            raise Exception("More than one project found")
+
+        if len(metas["projects"]) == 1:
+            meta = metas["projects"][0]
+            return meta
+
     def get_versions(self, project):
         return self.get_cached(self.VERSIONS_URL % project)
 

--- a/sentry_jira/jira.py
+++ b/sentry_jira/jira.py
@@ -21,6 +21,7 @@ class JIRAClient(object):
     CREATE_URL = '/rest/api/2/issue'
     PRIORITIES_URL = '/rest/api/2/priority'
     VERSIONS_URL = '/rest/api/2/project/%s/versions'
+    ISSUE_URL = '/rest/api/2/issue/%s'
     HTTP_TIMEOUT = 5
 
     def __init__(self, instance_uri, username, password):
@@ -58,6 +59,9 @@ class JIRAClient(object):
     def create_issue(self, raw_form_data):
         data = {'fields': raw_form_data}
         return self.make_request('post', self.CREATE_URL, payload=data)
+
+    def get_issue(self, key):
+        return self.make_request('get', self.ISSUE_URL % key)
 
     def make_request(self, method, url, payload=None):
         if url[:4] != "http":

--- a/sentry_jira/plugin.py
+++ b/sentry_jira/plugin.py
@@ -137,7 +137,7 @@ class JIRAPlugin(IssuePlugin):
         issue_key = GroupMeta.objects.get_value(group, '%s:tid' % self.get_conf_key(), None)
         if issue_key:
             self.update_issue_key(group)
-            return None
+            return self.redirect(reverse('sentry-group', args=[group.team.slug, group.project_id, group.pk]))
 
         #######################################################################
         # Auto-complete handler

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ f.close()
 
 setup(
     name='sentry-jira',
-    version='0.8.0',
+    version='0.8.2',
     author='Adam Thurlow',
     author_email='thurloat@gmail.com',
     url='http://github.com/thurloat/sentry-jira',


### PR DESCRIPTION
@rogerhu has done some excellent work which has been sitting in a PR on the main repo (https://github.com/thurloat/sentry-jira/pull/61) which we have been using happily in production. 

This PR also includes some changes that we made at MapMyFitness. Our workflow involves creating a ticket in a single JIRA project and then moving that ticket to one of a number of projects depending on what team will be fixing it. This change (5fb5e1b37341a5591a863830b27c538c1fc1795d) adds two links to the sidebar of the group detail page: one is a link to the JIRA issue, the other is a link that refetches the ticket information and updates the tag to reflect the new ticket issue key.