### PR TITLE
Swap out requests for sentry.http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 sentry.conf.py
 *.pyc
+*.egg-info
 .idea/
 env/

--- a/sentry_jira/forms.py
+++ b/sentry_jira/forms.py
@@ -41,9 +41,9 @@ class JIRAOptionsForm(forms.Form):
 
         initial = kwargs.get("initial")
         project_safe = False
-        if initial:
+        if initial and initial.get("instance_url"):
             # make a connection to JIRA to fetch a default project.
-            jira = JIRAClient(initial.get("instance_url"), initial.get("username"), initial.get("password"))
+            jira = JIRAClient(initial["instance_url"], initial.get("username"), initial.get("password"))
             projects_response = jira.get_projects_list()
             if projects_response.status_code == 200:
                 projects = projects_response.json
@@ -148,7 +148,7 @@ class JIRAIssueForm(forms.Form):
         versions = jira_client.get_versions(initial.get("project_key")).json
 
         # Returns the metadata the configured JIRA instance requires for
-        # creating issues for a given project. 
+        # creating issues for a given project.
         # https://developer.atlassian.com/static/rest/jira/5.0.html#id200251
         meta = jira_client.get_create_meta(initial.get("project_key")).json
 

--- a/sentry_jira/jira.py
+++ b/sentry_jira/jira.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import
+
 import logging
-import requests
+
+from sentry.http import build_session
 from sentry.utils import json
 from sentry.utils.cache import cache
 from simplejson.decoder import JSONDecodeError
@@ -48,15 +51,16 @@ class JIRAClient(object):
         if url[:4] != "http":
             url = self.instance_url + url
         auth = self.username, self.password
-        headers = {'content-type': 'application/json'}
+        session = build_session()
         try:
             if method == 'get':
-                r = requests.get(url, params=payload, auth=auth, headers=headers,
-                                 verify=False, timeout=self.HTTP_TIMEOUT)
+                r = session.get(
+                    url, params=payload, auth=auth,
+                    verify_ssl=False, timeout=self.HTTP_TIMEOUT)
             else:
-                r = requests.post(url, data=json.dumps(payload), auth=auth,
-                                  headers=headers, verify=False,
-                                  timeout=self.HTTP_TIMEOUT)
+                r = session.post(
+                    url, json=payload, auth=auth,
+                    verify_ssl=False, timeout=self.HTTP_TIMEOUT)
             return JIRAResponse(r.text, r.status_code)
         except Exception, e:
             logging.error('Error in request to %s: %s', url, e.message)

--- a/sentry_jira/jira.py
+++ b/sentry_jira/jira.py
@@ -21,6 +21,7 @@ class JIRAClient(object):
     CREATE_URL = '/rest/api/2/issue'
     PRIORITIES_URL = '/rest/api/2/priority'
     VERSIONS_URL = '/rest/api/2/project/%s/versions'
+    HTTP_TIMEOUT = 5
 
     def __init__(self, instance_uri, username, password):
         self.instance_url = instance_uri
@@ -50,9 +51,12 @@ class JIRAClient(object):
         headers = {'content-type': 'application/json'}
         try:
             if method == 'get':
-                r = requests.get(url, params=payload, auth=auth, headers=headers, verify=False)
+                r = requests.get(url, params=payload, auth=auth, headers=headers,
+                                 verify=False, timeout=self.HTTP_TIMEOUT)
             else:
-                r = requests.post(url, data=json.dumps(payload), auth=auth, headers=headers, verify=False)
+                r = requests.post(url, data=json.dumps(payload), auth=auth,
+                                  headers=headers, verify=False,
+                                  timeout=self.HTTP_TIMEOUT)
             return JIRAResponse(r.text, r.status_code)
         except Exception, e:
             logging.error('Error in request to %s: %s' % (url, e.message))

--- a/sentry_jira/jira.py
+++ b/sentry_jira/jira.py
@@ -59,7 +59,7 @@ class JIRAClient(object):
                                   timeout=self.HTTP_TIMEOUT)
             return JIRAResponse(r.text, r.status_code)
         except Exception, e:
-            logging.error('Error in request to %s: %s' % (url, e.message))
+            logging.error('Error in request to %s: %s', url, e.message)
             return JIRAResponse("There was a problem reaching %s: %s" % (url, e.message), 500)
 
     def get_cached(self, full_url):

--- a/sentry_jira/plugin.py
+++ b/sentry_jira/plugin.py
@@ -78,13 +78,13 @@ class JIRAPlugin(IssuePlugin):
             # return some sort of error.
             errdict = {"__all__": None}
             if issue_response.status_code == 500:
-                errdict["__all__"] = "JIRA Internal Server Error."
+                errdict["__all__"] = ["JIRA Internal Server Error."]
             elif issue_response.status_code == 400:
                 for k in issue_response.json["errors"].keys():
                     errdict[k] = [issue_response.json["errors"][k],]
-                errdict["__all__"] = issue_response.json["errorMessages"]
+                errdict["__all__"] = [issue_response.json["errorMessages"]]
             else:
-                errdict["__all__"] = "Something went wrong, Sounds like a configuration issue: code %s" % issue_response.status_code
+                errdict["__all__"] = ["Something went wrong, Sounds like a configuration issue: code %s" % issue_response.status_code]
             return None, errdict
 
     def get_issue_url(self, group, issue_id, **kwargs):

--- a/sentry_jira/plugin.py
+++ b/sentry_jira/plugin.py
@@ -165,7 +165,7 @@ class JIRAPlugin(IssuePlugin):
             if form.is_valid():
                 GroupMeta.objects.set_value(group, '%s:tid' % prefix, issue_id)
 
-                return self.redirect(reverse('sentry-group', args=[group.team.slug, group.project_id, group.pk]))
+                return self.redirect(group.get_absolute_url())
         else:
             for name, field in form.fields.items():
                 form.errors[name] = form.error_class()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'sentry>=6.0.0',
-    'requests>=1.2.0',
     'BeautifulSoup>=3.2.1'
 ]
 


### PR DESCRIPTION
This switches to the internal sentry.http client (which is requests-backed).

The goal here is to future proof HTTP requests, as we disallow some things by default as well as ensure a user-agent is sent.
