### PR TITLE
Fix JSON formatting when POST date type.

### DIFF
--- a/sentry_jira/forms.py
+++ b/sentry_jira/forms.py
@@ -252,6 +252,8 @@ class JIRAIssueForm(forms.Form):
                     schema = f["schema"]
                     if schema.get("type") == "string" and not schema.get("custom") == CUSTOM_FIELD_TYPES["select"]:
                         continue  # noop
+                    if schema.get("type") == "date":
+                        continue
                     if schema["type"] == "user" or schema.get('item') == "user":
                         v = {"name": v}
                     elif schema.get("custom") == CUSTOM_FIELD_TYPES.get("multiuserpicker"):


### PR DESCRIPTION
old fashion would post duedate field as
    "duedate": {"id": "2015-07-31"}
but Jira refused it: "Operation value must be a string"
this commit fix the formatting. Tested on Jira 6.4.4
