### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ More Documentation
 ------------------
 
 Have a look at the readthedocs page for more detailed configuration steps and a
-changelog: http://sentry-jira.readthedocs.org/en/latest/
+changelog: https://sentry-jira.readthedocs.io/en/latest/
 
 License
 -------

--- a/sentry_jira/plugin.py
+++ b/sentry_jira/plugin.py
@@ -33,7 +33,7 @@ class JIRAPlugin(IssuePlugin):
     # Adding resource links for forward compatibility, still need to integrate
     # into existing `project_conf.html` template.
     resource_links = [
-        ("Documentation", "http://sentry-jira.readthedocs.org/en/latest/"),
+        ("Documentation", "https://sentry-jira.readthedocs.io/en/latest/"),
         ("README", "https://raw.github.com/thurloat/sentry-jira/master/README.rst"),
         ("Bug Tracker", "https://github.com/thurloat/sentry-jira/issues"),
         ("Source", "http://github.com/thurloat/sentry-jira"),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
