### PR TITLE
plugin: fix wrong id for for project autocreation

### DIFF
--- a/sentry_jira/plugin.py
+++ b/sentry_jira/plugin.py
@@ -342,7 +342,7 @@ class JIRAPlugin(IssuePlugin):
         project = meta["projects"][0]
 
         post_data = {
-            'project': {'id': project},
+            'project': {'id': project['id']},
             'summary': initial['summary'],
             'description': initial['description'],
         }


### PR DESCRIPTION
- Fix a bug where the project id wasn't correctly sent to jira
  but the complete dictionnary was. This should allow autocreation
  of ticket for new issues.

Signed-off-by: Guillaume Lastecoueres guillaume@tind.io

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-jira/109)

<!-- Reviewable:end -->
